### PR TITLE
get_batch

### DIFF
--- a/benchmarks/compare_get_batch.py
+++ b/benchmarks/compare_get_batch.py
@@ -1,0 +1,49 @@
+import asyncio
+import logging
+import time
+
+from httpxthrottlecache import HttpxThrottleCache
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+url = "https://httpbingo.org/get"
+CACHE_DIR = "_cache"
+
+
+def test_get_batch():
+    with HttpxThrottleCache(cache_dir=CACHE_DIR, cache_mode="FileCache") as manager:
+        manager.cache_rules = {"httpbingo.com": {"/file.bin": 5}}  # force stale without monkeypatching time
+        manager.get_batch([url for _ in range(10)])
+
+
+def test_serial_sync():
+    with HttpxThrottleCache(cache_dir=CACHE_DIR, cache_mode="FileCache") as manager:
+        with manager.http_client() as client:
+            manager.cache_rules = {"httpbingo.com": {"/file.bin": 5}}  # force stale without monkeypatching time
+            [client.get(url) for _ in range(10)]
+
+
+async def test_async():
+    with HttpxThrottleCache(cache_dir=CACHE_DIR, cache_mode="FileCache") as manager:
+        async with manager.async_http_client() as client:
+            manager.cache_rules = {"httpbingo.com": {"/file.bin": 5}}  # force stale without monkeypatching time
+            await asyncio.gather(*[client.get(url) for _ in range(10)])
+
+
+if __name__ == "__main__":
+    s1 = time.perf_counter()
+    test_get_batch()
+    e1 = time.perf_counter()
+
+    s2 = time.perf_counter()
+    test_serial_sync()
+    e2 = time.perf_counter()
+
+    s3 = time.perf_counter()
+    asyncio.run(test_async())
+    e3 = time.perf_counter()
+
+    logger.info("test_get_batch took %d", e1 - s1)
+    logger.info("test_serial_sync took %d", e2 - s2)
+    logger.info("test_async took %d", e3 - s3)

--- a/httpxthrottlecache/filecache/transport.py
+++ b/httpxthrottlecache/filecache/transport.py
@@ -109,7 +109,7 @@ class FileCache:
             logger.info("Cache policy allows unlimited cache, returning %s", p)
             return True, p
 
-        age = time.time() - fetched
+        age = round(time.time() - fetched)
         if age < 0:  # pragma: no cover
             raise ValueError(f"Age is less than 0, impossible {age=}, file {path=}")
         logger.info("file is %s seconds old, policy allows caching for up to %s", age, cached)
@@ -246,8 +246,8 @@ class CachingTransport(httpx.BaseTransport, httpx.AsyncBaseTransport):
 
     def _cache_hit_response(self, req, path: Path, status_code: int = 200):
         """
-        TODO: More carefully consider async here. read_text, read_bytes both are blocking. 
-        
+        TODO: More carefully consider async here. read_text, read_bytes both are blocking.
+
         Large files are streamed async, so the only blocking events here are for reading small(ish) files
         """
         meta = json.loads(path.with_suffix(path.suffix + ".meta").read_text())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,8 +26,13 @@ def manager_nocache():
 
 
 def mock_client(client):
+
+    class _MockAsyncStream(httpx.AsyncByteStream):
+        async def __aiter__(self): yield b"ok"
+        async def aclose(self): pass
+
     async def _handler(req): 
-        return httpx.Response(200, content=b"ok", headers={"date": "Mon, 01 Jan 2024 00:00:00 GMT"}, request=req)
+        return httpx.Response(200, headers={"date":"Mon, 01 Jan 2024 00:00:00 GMT"}, request=req, stream=_MockAsyncStream())
 
     next_transport = httpx.MockTransport(_handler)
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,12 @@
+from conftest import mock_client
+
+def test_batch(manager_cache):
+    url = "https://example.com/file.bin"
+    manager_cache.cache_rules = {"example.com": {"/file.bin": 5}}  # force stale without monkeypatching time
+
+    urls = [url for _ in range(10)]
+
+    results = manager_cache.get_batch(urls, mock_client)
+
+    for r in results:
+        assert r[0] in (200, 304)


### PR DESCRIPTION
Add `get_batch`: a convenience function to retrieve multiple URLs. This is done by spawning an asyncio loop in a separate thread. Why a separate thread? Because that's easier than handling both the "we're in an asyncio loop already" and "we're not in an an asyncio loop so let's start one". 